### PR TITLE
Add the ability to store information on schema types

### DIFF
--- a/NEWS.org
+++ b/NEWS.org
@@ -1,5 +1,9 @@
 TITLE: Changelog for the triples module for GNU Emacs.
 
+* 0.7.0
+- Add the ability to store information on schema types.
+* 0.6.0
+- Add a float type
 * 0.5.1
 - Add an optional limit for =triples-search=, and document it.
 * 0.5.0

--- a/triples-backups.el
+++ b/triples-backups.el
@@ -24,6 +24,8 @@
 
 (require 'triples)
 
+(declare-function emacsql-sqlite-open "emacsql")
+
 ;;; Code:
 
 (defun triples-backups-setup (db num-to-keep strategy)

--- a/triples.el
+++ b/triples.el
@@ -6,7 +6,7 @@
 ;; Homepage: https://github.com/ahyatt/triples
 ;; Package-Requires: ((seq "2.0") (emacs "28.1"))
 ;; Keywords: triples, kg, data, sqlite
-;; Version: 0.7.0
+;; Version: 0.6.0
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
 ;; published by the Free Software Foundation; either version 2 of the

--- a/triples.el
+++ b/triples.el
@@ -6,7 +6,7 @@
 ;; Homepage: https://github.com/ahyatt/triples
 ;; Package-Requires: ((seq "2.0") (emacs "28.1"))
 ;; Keywords: triples, kg, data, sqlite
-;; Version: 0.6.0
+;; Version: 0.7.0
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as
 ;; published by the Free Software Foundation; either version 2 of the
@@ -42,6 +42,7 @@
 (declare-function emacsql-close "emacsql")
 (declare-function emacsql-sqlite "emacsql")
 (declare-function emacsql "emacsql")
+(declare-function emacsql-sqlite-open "emacsql")
 
 (defvar triples-sqlite-interface
   (if (and (fboundp 'sqlite-available-p) (sqlite-available-p))
@@ -61,6 +62,11 @@ It is invoked to make backups.")
   "The default filename triples database.
 
 If no database is specified, this file is used.")
+
+(defconst triples-basic-types '(integer float string symbol vector cons)
+  "Possible values for :base/type for objects.
+
+Everything here must be returnable by `type-of'.")
 
 (defmacro triples-with-transaction (db &rest body)
   "Create a transaction using DB, executing BODY.
@@ -513,7 +519,16 @@ definitions."
                                (cdr (assoc (nth 1 triple) prop-schema-alist)))) triples))
 
 (defun triples-add-schema (db type &rest props)
-  "Add schema for TYPE and its PROPS to DB."
+  "Add schema for TYPE and its PROPS to DB.
+If a `:base/type' is not specified, it is assumed to be a string."
+  ;; First, make sure all props are compliant with `triples-basic-types'.
+  (mapc (lambda (prop)
+          (when (consp prop)
+            (let ((settings (cdr prop)))
+              (when (and (plistp settings) (plist-get settings :base/type)
+                         (not (member (plist-get settings :base/type) triples-basic-types)))
+                (error "Property types must be a in `triples-basic-types'")))))
+        props)
   (triples--add db (apply #'triples--add-schema-op type props)))
 
 (defun triples--add-schema-op (type &rest props)
@@ -564,9 +579,14 @@ PROPERTIES is a plist of properties, without TYPE prefixes."
              (triples-properties-for-predicate db (triples-type-and-prop-to-combined type 'schema/property)))
             (mapcar (lambda (prop)
                       (cons (triples--decolon prop)
-                            (triples-properties-for-predicate
-                             db
-                             (triples-type-and-prop-to-combined type prop))))
+                            (triples--plist-mapcan
+                             (lambda (prop value)
+                               (when (or (not (eq prop :base/type))
+                                         (member value triples-basic-types))
+                                 (list prop value)))
+                             (triples-properties-for-predicate
+                              db
+                              (triples-type-and-prop-to-combined type prop)))))
                     (triples--plist-mapcar (lambda (k _) k) properties))))
          (op (triples--set-type-op subject type properties prop-schema-alist)))
     (triples-verify-schema-compliant


### PR DESCRIPTION
We also enforce schema properties types are in the set of basic types, as outlined in the README.

